### PR TITLE
feat: polish UI with subtle loading and remove redundant elements

### DIFF
--- a/src/app/exchange-users/page.tsx
+++ b/src/app/exchange-users/page.tsx
@@ -86,14 +86,28 @@ export default function ExchangeUsersPage() {
   useEffect(() => {
     fetchExchanges();
   }, []);
-return (
+
+  useEffect(() => {
+    fetchUsers();
+  }, [selectedExchangeId, sortBy, sortOrder]);
+
+  if (loading) return <Loading />;
+  if (error && exchanges.length === 0) {
+    return <ErrorMessage message={error} onRetry={fetchExchanges} />;
+  }
+
+  return (
     <>
-      {loadingUsers ? (
-        <Loading />
-      ) : error ? (
+      {error ? (
         <ErrorMessage message={error} onRetry={fetchUsers} />
       ) : selectedExchangeId ? (
-        <ExchangeUserList 
+        <div className="relative">
+          {loadingUsers && (
+            <div className="absolute top-0 right-0 mt-2 mr-2">
+              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
+            </div>
+          )}
+          <ExchangeUserList 
           users={users} 
           exchanges={exchanges}
           selectedExchangeId={selectedExchangeId}
@@ -102,21 +116,12 @@ return (
           sortOrder={sortOrder}
           onSort={handleSort}
         />
+        </div>
       ) : (
         <div className="text-center py-12">
           <p className="text-gray-500">Please select an exchange to view users.</p>
         </div>
       )}
-    </iv>
-
-      {/* Users List */}
-      {loadingUsers ? (
-        <Loading />
-      ) : error ? (
-        <ErrorMessage message={error} onRetry={fetchUsers} />
-      ) : selectedExchangeId ? (
-        <ExchangeUserList users={users} exchanges={exchanges} />
-      ) : null}
-    </div>
+    </>
   );
 }

--- a/src/components/exchangeUsers/ExchangeUserList.tsx
+++ b/src/components/exchangeUsers/ExchangeUserList.tsx
@@ -92,8 +92,7 @@ export function ExchangeUserList({
       </div>
 
       {/* Segmented Control for Exchange Selection */}
-      <div className="mt-6 flex items-center gap-2">
-        <span className="text-sm font-medium text-gray-700">Exchange:</span>
+      <div className="mt-6">
         <div className="inline-flex rounded-lg border border-gray-300 bg-white p-1 shadow-sm">
           {exchanges.map((exchange) => (
             <button
@@ -101,7 +100,32 @@ export function ExchangeUserList({
               type="button"
               onClick={() => onExchangeChange(exchange.id)}
               className={`
-                px-4 p<button
+                px-4 py-2 text-sm font-medium rounded-md transition-all
+                ${
+                  selectedExchangeId === exchange.id
+                    ? 'bg-blue-600 text-white shadow-sm'
+                    : 'text-gray-700 hover:bg-gray-50'
+                }
+              `}
+            >
+              {exchange.display_name}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-8 flow-root">
+        <div className="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+          <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+            <div className="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
+              <table className="min-w-full divide-y divide-gray-300">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th
+                      scope="col"
+                      className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6"
+                    >
+                      <button
                         type="button"
                         onClick={() => onSort('name')}
                         className="group inline-flex items-center gap-1 hover:text-blue-600"
@@ -109,12 +133,6 @@ export function ExchangeUserList({
                         Name
                         {getSortIcon('name')}
                       </button>
-                    </th>
-                    <th
-                      scope="col"
-                      className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
-                    >
-                      Exchange
                     </th>
                     <th
                       scope="col"
@@ -140,32 +158,7 @@ export function ExchangeUserList({
                       >
                         Created
                         {getSortIcon('created_at')}
-                      </button>e="min-w-full divide-y divide-gray-300">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th
-                      scope="col"
-                      className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6"
-                    >
-                      Name
-                    </th>
-                    <th
-                      scope="col"
-                      className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
-                    >
-                      Exchange
-                    </th>
-                    <th
-                      scope="col"
-                      className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
-                    >
-                      External ID
-                    </th>
-                    <th
-                      scope="col"
-                      className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
-                    >
-                      Created
+                      </button>
                     </th>
                     <th scope="col" className="relative py-3.5 pl-3 pr-4 sm:pr-6">
                       <span className="sr-only">View</span>
@@ -177,9 +170,6 @@ export function ExchangeUserList({
                     <tr key={user.id} className="hover:bg-gray-50">
                       <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
                         {user.name}
-                      </td>
-                      <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                        {getExchangeName(user.exchange_id)}
                       </td>
                       <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                         {user.external_user_id}


### PR DESCRIPTION
# Polish ExchangeUser List UI

## 🎯 Objectif
Améliorer l'UX de la liste des ExchangeUsers en éliminant les éléments redondants et en optimisant le feedback visuel pendant le chargement.

## 🔧 Changements

### Suppression d'éléments redondants
- **Label "Exchange:"**: Retiré devant le contrôle segmenté (redondant car self-explanatory)
- **Colonne Exchange**: Supprimée du tableau car l'utilisateur filtre déjà par exchange

### Amélioration du chargement
- **Avant**: Affichage d'un composant `<Loading />` plein écran causant un clignotement
- **Après**: Petit spinner (6x6) en haut à droite qui reste discret
- **Bénéfice**: Les données restent visibles pendant le rechargement, meilleure perception de performance

### Refactorisation du state
- Séparation claire entre `loading` (chargement initial) et `loadingUsers` (rafraîchissement)
- `useEffect` séparés pour chargement initial et rechargement des données
- Gestion cohérente des états d'erreur

## 🎨 Impact UX
- ✨ Interface plus épurée et moderne
- ⚡ Transitions plus fluides sans interruption visuelle
- 🎯 Focus sur les données importantes (pas de duplication d'informations)

## 📸 Comportement
1. Au chargement initial: spinner plein écran
2. Lors du changement d'exchange: petit spinner en haut à droite, données actuelles restent visibles
3. Lors du tri: même comportement que (2)

## ✅ Tests
- Vérifier l'affichage du contrôle segmenté (sans label)
- Vérifier que la colonne Exchange n'apparaît plus dans le tableau
- Vérifier le comportement du loading lors du changement d'exchange
- Vérifier le comportement du loading lors du tri

## 🔗 Liens
- Related PR: https://github.com/benjaminhallouin/zapallo-web/pull/33
